### PR TITLE
feat(docker): add OCI labels for image metadata and description

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,11 @@ RUN apk add --no-cache \
   ca-certificates \
   wget
 
+# Add Open Container Initiative (OCI) labels
+LABEL org.opencontainers.image.source=https://github.com/yerTools/simple-frontend-stack
+LABEL org.opencontainers.image.description="A lightweight frontend stack for rapid web app development powered by SolidJS, TailwindCSS, and DaisyUI. Includes optional PocketBase backend with Bun and Vite for blazing-fast development workflow."
+LABEL org.opencontainers.image.licenses=MIT
+
 # Set the working directory
 WORKDIR /app
 


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change adds Open Container Initiative (OCI) labels to provide metadata about the image, such as its source, description, and license.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R67-R71): Added OCI labels for image source, description, and licenses.